### PR TITLE
Draft aggregate-commit-renames functionality

### DIFF
--- a/git-filter-multirepo
+++ b/git-filter-multirepo
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+import subprocess
+
+try:
+    from git_filter_repo import RepoFilter, FilteringOptions, _read_commit_map_from_file, FileChange
+except ImportError:
+    raise SystemExit(
+        "Error: Couldn't find git_filter_repo.py.  Did you forget to make a symlink to git-filter-repo named git_filter_repo.py or did you forget to put the latter in your PYTHONPATH?"
+    )
+
+
+FILE_MODE_SUBMODULE = b"160000"
+
+
+def parse_args(arguments):
+    parser = argparse.ArgumentParser(description="Run submodule aware git-filter-repo")
+    parser.add_argument("--commit-remap", type=os.fsencode, help=("Path to the commit remap"))
+    parsed_args, rest = parser.parse_known_args(arguments)
+    if not parsed_args.commit_remap:
+        raise SystemExit("Error: Need to specify the --commit-remap path")
+    return (parsed_args, rest)
+
+
+class SubmoduleRenames:
+    def __init__(self, path: bytes):
+        self._aggregated_commit_renames = _read_commit_map_from_file(path)
+        if not self._aggregated_commit_renames:
+            raise SystemExit("Error: empty commit remap")
+
+    def _remap_hash(self, file_change: FileChange) -> FileChange:
+        if (file_change.mode == FILE_MODE_SUBMODULE) and (file_change.blob_id in self._aggregated_commit_renames):
+            file_change.blob_id = self._aggregated_commit_renames[file_change.blob_id]
+        return file_change
+
+    def replace_submodule_renames(self, commit, metadata):
+        commit.file_changes = [self._remap_hash(file_change) for file_change in commit.file_changes]
+
+
+def main():
+    parsed_args, forward_args = parse_args(sys.argv[1:])
+    filtering_args = FilteringOptions.parse_args(forward_args)
+    submodule_renames = SubmoduleRenames(parsed_args.commit_remap)
+    if filtering_args.analyze:
+        RepoAnalyze.run(filtering_args)
+    else:
+        filter = RepoFilter(filtering_args, commit_callback=submodule_renames.replace_submodule_renames)
+        filter.run()
+
+
+if __name__ == "__main__":
+    main()
+
+# vim: set sw=2:

--- a/git-filter-multirepo
+++ b/git-filter-multirepo
@@ -6,7 +6,7 @@ import sys
 import subprocess
 
 try:
-    from git_filter_repo import RepoFilter, FilteringOptions, _read_commit_map_from_file, FileChange
+    from git_filter_repo import RepoFilter, FilteringOptions, _read_commit_map_from_file, deleted_hash, FileChange
 except ImportError:
     raise SystemExit(
         "Error: Couldn't find git_filter_repo.py.  Did you forget to make a symlink to git-filter-repo named git_filter_repo.py or did you forget to put the latter in your PYTHONPATH?"
@@ -31,7 +31,11 @@ class SubmoduleRenames:
 
     def _remap_hash(self, file_change: FileChange) -> FileChange:
         if (file_change.mode == FILE_MODE_SUBMODULE) and (file_change.blob_id in self._aggregated_commit_renames):
-            file_change.blob_id = self._aggregated_commit_renames[file_change.blob_id]
+            new_blob_id = self._aggregated_commit_renames[file_change.blob_id]
+            if new_blob_id == deleted_hash:
+                new_blob_id = file_change.blob_id
+                print("[WARNING] Commit referenced by {} was deleted due to previous filtering: it will not be replaced".format(file_change.filename))
+            file_change.blob_id = new_blob_id
         return file_change
 
     def replace_submodule_renames(self, commit, metadata):
@@ -52,4 +56,3 @@ def main():
 if __name__ == "__main__":
     main()
 
-# vim: set sw=2:

--- a/git-filter-multirepo
+++ b/git-filter-multirepo
@@ -20,8 +20,6 @@ def parse_args(arguments):
     parser = argparse.ArgumentParser(description="Run submodule aware git-filter-repo")
     parser.add_argument("--commit-remap", type=os.fsencode, help=("Path to the commit remap"))
     parsed_args, rest = parser.parse_known_args(arguments)
-    if not parsed_args.commit_remap:
-        raise SystemExit("Error: Need to specify the --commit-remap path")
     return (parsed_args, rest)
 
 

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -87,6 +87,28 @@ def _timedelta_to_seconds(delta):
   offset = delta.days*86400 + delta.seconds + (delta.microseconds+0.0)/1000000
   return round(offset)
 
+def _read_commit_map_from_file(path, metadata_dir=None, reverse = False):
+  """
+  Reads to dictionary files with SHA1 renaming
+  """
+  hash_mapping = {}
+  file_path = os.path.join(metadata_dir, path) if metadata_dir else path
+  try:
+    with open(file_path, 'br') as f:
+      check_commit_map_line_re = re.compile(b'^[0-9a-f]{40} [0-9a-f]{40}$')
+      for line in f:
+        if not check_commit_map_line_re.match(line):
+          continue
+        old_new_hash = line.rstrip(b"\n").split(b' ')
+        if not reverse:
+          hash_mapping[old_new_hash[0]] = old_new_hash[1]
+        else:
+          hash_mapping[old_new_hash[1]] = old_new_hash[0]
+  except IOError:
+    pass
+  finally:
+    return hash_mapping
+
 class FixedTimeZone(tzinfo):
   """
   Fixed offset in minutes east from UTC.
@@ -1671,6 +1693,10 @@ class FilteringOptions(object):
         namespace.path_changes = []
       namespace.path_changes += FilteringOptions.get_paths_from_file(values)
 
+  class AggregateCommitRenamesFileFilter(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+      namespace.aggregate_commit_renames_file = values
+
   @staticmethod
   def create_arg_parser():
     # Include usage in the summary, so we can put the description first
@@ -2014,6 +2040,10 @@ EXAMPLES
         #       "to new objects to the specified branch upon exit, and"
         #       "loading that mapping from that branch (if it exists) "
         #       "upon startup."))
+        help=argparse.SUPPRESS)
+    misc.add_argument('--aggregate-commit-renames-to', metavar='FILENAME',
+        type=os.fsencode,
+        action=FilteringOptions.AggregateCommitRenamesFileFilter, dest='aggregate_commit_renames_file',
         help=argparse.SUPPRESS)
     misc.add_argument('--stdin', action='store_true',
         help=_("Instead of running `git fast-export` and filtering its "
@@ -2774,6 +2804,15 @@ class RepoFilter(object):
     # the new_id can be None rather than a commit hash if the original
     # commit became empty and was pruned or was otherwise dropped.
     self._commit_renames = {}
+
+    # A dict of new_ids to riginal_ids from the previous run;
+    # It is used to construct the aggregated commit rename map
+    self._old_commit_reverse_renames = {}
+
+    # A dict of original_ids, from the first invocation,
+    # to new_ids, from the last invocation
+    # It is used to construct the aggregated commit rename map
+    self._aggregated_commit_renames = {}
 
     # A set of original_ids for which we have not yet gotten the
     # new_ids; we use OrderedDict because we need to know the order of
@@ -3774,13 +3813,35 @@ class RepoFilter(object):
     if p.wait():
       raise SystemExit(_("git update-ref failed; see above")) # pragma: no cover
 
+  def _read_aggregated_commit_renames(self):
+    aggregated_commit_reverse_renames = _read_commit_map_from_file(self._args.aggregate_commit_renames_file, reverse = True)
+    if not aggregated_commit_reverse_renames:
+      aggregated_commit_reverse_renames = self._old_commit_reverse_renames
+    if(self._args.debug):
+      print("[DEBUG] Reverse renames:\n" + str(aggregated_commit_reverse_renames))
+    if aggregated_commit_reverse_renames:
+      self._aggregated_commit_renames = {aggregated_commit_reverse_renames[k]:v for k,v in self._commit_renames.items() if k != deleted_hash}
+
   def _record_metadata(self, metadata_dir, orig_refs):
     self._flush_renames()
+
+    if self._args.aggregate_commit_renames_file and not self._aggregated_commit_renames:
+      # Read the old commit renames just before overwriting
+      self._old_commit_reverse_renames = _read_commit_map_from_file(b'commit-map', metadata_dir, reverse = True)
+
     with open(os.path.join(metadata_dir, b'commit-map'), 'bw') as f:
       f.write(("%-40s %s\n" % (_("old"), _("new"))).encode())
       for (old,new) in self._commit_renames.items():
         msg = b'%s %s\n' % (old, new if new != None else deleted_hash)
         f.write(msg)
+
+    if self._args.aggregate_commit_renames_file:
+      self._read_aggregated_commit_renames()
+      with open(self._args.aggregate_commit_renames_file, 'bw') as f:
+        f.write(("%-40s %s\n" % (_("old"), _("new"))).encode())
+        for (old,new) in self._aggregated_commit_renames.items():
+          msg = b'%s %s\n' % (old, new if new != None else deleted_hash)
+          f.write(msg)
 
     exported_refs, imported_refs = self.get_exported_and_imported_refs()
 
@@ -3978,3 +4039,5 @@ def main():
 
 if __name__ == '__main__':
   main()
+
+# vim: set sw=2:

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -3821,6 +3821,8 @@ class RepoFilter(object):
       print("[DEBUG] Reverse renames:\n" + str(aggregated_commit_reverse_renames))
     if aggregated_commit_reverse_renames:
       self._aggregated_commit_renames = {aggregated_commit_reverse_renames[k]:v for k,v in self._commit_renames.items() if k != deleted_hash}
+    else:
+      self._aggregated_commit_renames = self._commit_renames
 
   def _record_metadata(self, metadata_dir, orig_refs):
     self._flush_renames()


### PR DESCRIPTION
Add `--aggregate-commit-renames-to=file` option.

The purpose is to use it in the context of complex repositories with many submodules.
The main git repo needs a way to determine how to convert submodule blobs to match the new submodule hashes of the filtered submodules. Therefore we need to map the very first hashes to the very last ones, across several commands.

A typical use case could be any succession of `git filter-repo ...` commands. E.g.:

```bash
git filter-repo --aggregate-commit-renames-to=./remap --invert-paths --path-regex '.*gray.*'
git filter-repo --aggregate-commit-renames-to=./remap --invert-paths --path-regex '.*black.*'
```

The remap will contain a commit-renames like structure
```
old                 new
(most ancient sha1) (latest corresponding sha1)
```

The output path is intentionally caller defined, since the caller itself will need to use it in some form of postprocessing (a blob callback in this case)